### PR TITLE
Added custom JIT minhash document signer implimentation

### DIFF
--- a/minlizhash/__init__.py
+++ b/minlizhash/__init__.py
@@ -1,4 +1,4 @@
-from . import LSH, hash, min_hash, tokens, types, utils
+from . import LSH, hash, jit, min_hash, tokens, types, utils
 from .hash import Hasher
 from .LSH import LSHIndex, check_candidatelist, filter_checked_candidates
 from .min_hash import (
@@ -27,4 +27,5 @@ __all__ = [
     tokens,
     types,
     utils,
+    jit,
 ]

--- a/minlizhash/hash.py
+++ b/minlizhash/hash.py
@@ -118,14 +118,18 @@ class Hasher:
         new_doc["signature"] = self.gen_signature(document["tokens"])
         return new_doc
 
-    def sign_documents_batch(self, documents: list[Document], inplace=False, mp=False):
+    def sign_documents_batch(
+        self, documents: list[Document], inplace=False, mp=False, progress_bar=True
+    ):
+        if progress_bar:
+            documents = tqdm(documents)
         if inplace:
-            for doc in tqdm(documents):
+            for doc in documents:
                 self.sign_document_inplace(doc)
         if mp:
             return self._sign_documents_batch_mp(documents)
         else:
-            return [self.sign_document(doc) for doc in tqdm(documents)]
+            return [self.sign_document(doc) for doc in documents]
 
     def sign_document_inplace(self, document: Document) -> None:
         """takes a Document object and adds a signature to it inplace"""

--- a/minlizhash/hash.py
+++ b/minlizhash/hash.py
@@ -118,9 +118,10 @@ class Hasher:
         new_doc["signature"] = self.gen_signature(document["tokens"])
         return new_doc
 
-    def sign_documents_batch(
+    def sign_documents(
         self, documents: list[Document], inplace=False, mp=False, progress_bar=True
     ):
+        """takes a list of Document objects and returns a new list of Document objects with the same ids and tokens, but with signatures"""
         if progress_bar:
             documents = tqdm(documents)
         if inplace:

--- a/minlizhash/hash.py
+++ b/minlizhash/hash.py
@@ -4,6 +4,7 @@ from multiprocessing import Pool
 from typing import Callable, List
 
 import numpy as np
+import numpy.typing as npt
 from tqdm import tqdm
 from xxhash import xxh32_intdigest
 
@@ -30,7 +31,9 @@ class DocumentSignerMinAfter(DocumentSigner):
     def __call__(
         self, tokens: TokenArray, seeds: PermutationSeeds
     ) -> DocumentSignature:
-        res = np.zeros((tokens.shape[0], len(seeds)), dtype=np.uint64)
+        res: npt.NDArray[np.uint64] = np.zeros(
+            (tokens.shape[0], len(seeds)), dtype=np.uint64
+        )
         for i in range(tokens.shape[0]):
             res[i] = self._hash_function_vec(tokens[i], seeds)
         # get min for each column
@@ -48,7 +51,7 @@ class DocumentSignerMinBefore(DocumentSigner):
 
     # self._hash_function_vec = np.vectorize(hash_function, excluded=['seed'], otypes=[np.uint64])
     def _hash_single_seed(self, tokens: TokenArray, seed: int) -> np.uint64:
-        empty = np.empty((tokens.shape[0],), dtype=np.uint64)
+        empty: npt.NDArray[np.uint64] = np.empty((tokens.shape[0],), dtype=np.uint64)
         for i in range(tokens.shape[0]):
             empty[i] = self.hash_function(tokens[i].tobytes(), seed)
         return empty.min()

--- a/minlizhash/jit.py
+++ b/minlizhash/jit.py
@@ -1,0 +1,100 @@
+import struct
+from typing import Callable
+
+import numpy as np
+import numpy.typing as npt
+from numba import jit, njit
+
+from .types import DocumentSignature, DocumentSigner, PermutationSeeds, TokenArray
+
+FNV_32_PRIME = 0x01000193
+FNV_64_PRIME = 0x100000001B3
+
+FNV0_32_INIT = 0
+FNV0_64_INIT = 0
+FNV1_32_INIT = 0x811C9DC5
+FNV1_32A_INIT = FNV1_32_INIT
+FNV1_64_INIT = 0xCBF29CE484222325
+FNV1_64A_INIT = FNV1_64_INIT
+
+
+@njit
+def int32_to_bytes(x):
+    return (x >> 24 & 0xFF, x >> 16 & 0xFF, x >> 8 & 0xFF, x & 0xFF)
+
+
+@njit
+def int64_to_bytes(x):
+    return (
+        x >> 56 & 0xFF,
+        x >> 48 & 0xFF,
+        x >> 40 & 0xFF,
+        x >> 32 & 0xFF,
+        x >> 24 & 0xFF,
+        x >> 16 & 0xFF,
+        x >> 8 & 0xFF,
+        x & 0xFF,
+    )
+
+
+@njit
+def fnv1a32(data: np.int32, seed: np.int32):
+    """
+    Returns the 32 bit FNV-1a hash value for the given data.
+    """
+    # assert isinstance(data, bytes)
+
+    hval = 0x811C9DC5 ^ seed
+    for byte in int32_to_bytes(data):
+        hval = hval ^ byte
+        hval = (hval * 0x01000193) % 2**32
+    return np.uint64(hval)
+
+
+@njit
+def fnv1a64(data: np.int32, seed: np.int32):
+    """
+    Returns the 64 bit FNV-1a hash value for the given data.
+    """
+    # assert isinstance(data, bytes)
+
+    hval = 0xCBF29CE484222325 ^ seed
+    for byte in int64_to_bytes(data):
+        hval = hval ^ byte
+        hval = (hval * 0x100000001B3) % 2**64
+    return hval
+
+
+@njit
+def minhash_jit(
+    tokens: npt.NDArray[np.int32],
+    hash_seed: np.int32,  # ,
+    # hash_fn: Callable[[bytes, int], int] = fnv1a,
+) -> np.uint64:
+    empty: npt.NDArray[np.uint64] = np.empty((tokens.shape[0],), dtype=np.uint64)
+    for i in range(tokens.shape[0]):
+        empty[i] = fnv1a32(tokens[i], hash_seed)
+    return empty.min()
+
+
+@njit
+def minhash_jit_all(
+    tokens: npt.NDArray[np.int32],
+    seeds: npt.NDArray[np.int32],
+) -> npt.NDArray[np.uint64]:
+    signature = np.zeros((seeds.shape[0],), dtype=np.uint64)
+    for i in range(signature.shape[0]):
+        signature[i] = minhash_jit(tokens, seeds[i])
+    return signature
+
+
+class DocumentSignerJIT(DocumentSigner):
+    """Signs the document token by token, vectorizing across the seeds for each iteration"""
+
+    def __init__(self, hash_function: Callable[[TokenArray, int], int] = minhash_jit):
+        self.hash_function = hash_function
+
+    def __call__(
+        self, tokens: TokenArray, seeds: PermutationSeeds
+    ) -> npt.NDArray[np.uint64]:
+        return minhash_jit_all(tokens, seeds)

--- a/minlizhash/jit.py
+++ b/minlizhash/jit.py
@@ -4,7 +4,6 @@ from typing import Callable
 import numpy as np
 import numpy.typing as npt
 from numba import njit
-from numba.typed import List
 
 from .types import DocumentSigner, PermutationSeeds, TokenArray
 

--- a/minlizhash/jit.py
+++ b/minlizhash/jit.py
@@ -4,8 +4,15 @@ from typing import Callable
 import numpy as np
 import numpy.typing as npt
 from numba import jit, njit
+from numba.typed import List
 
-from .types import DocumentSignature, DocumentSigner, PermutationSeeds, TokenArray
+from .types import (
+    Document,
+    DocumentSignature,
+    DocumentSigner,
+    PermutationSeeds,
+    TokenArray,
+)
 
 FNV_32_PRIME = 0x01000193
 FNV_64_PRIME = 0x100000001B3
@@ -78,7 +85,7 @@ def minhash_jit(
 
 
 @njit
-def minhash_jit_all(
+def sign_tokens_jit(
     tokens: TokenArray,
     seeds: PermutationSeeds,
 ) -> npt.NDArray[np.uint64]:
@@ -95,4 +102,4 @@ class DocumentSignerJIT(DocumentSigner):
         self.hash_function = hash_function
 
     def __call__(self, tokens, seeds) -> npt.NDArray[np.uint64]:
-        return minhash_jit_all(tokens.astype(np.uint64), seeds[:, 0])
+        return sign_tokens_jit(tokens.astype(np.uint64), seeds[:, 0])

--- a/minlizhash/jit.py
+++ b/minlizhash/jit.py
@@ -3,81 +3,32 @@ from typing import Callable
 
 import numpy as np
 import numpy.typing as npt
-from numba import jit, njit
+from numba import njit
 from numba.typed import List
 
-from .types import (
-    Document,
-    DocumentSignature,
-    DocumentSigner,
-    PermutationSeeds,
-    TokenArray,
-)
-
-FNV_32_PRIME = 0x01000193
-FNV_64_PRIME = 0x100000001B3
-
-FNV0_32_INIT = 0
-FNV0_64_INIT = 0
-FNV1_32_INIT = 0x811C9DC5
-FNV1_32A_INIT = FNV1_32_INIT
-FNV1_64_INIT = 0xCBF29CE484222325
-FNV1_64A_INIT = FNV1_64_INIT
+from .types import DocumentSigner, PermutationSeeds, TokenArray
 
 
 @njit
-def int32_to_bytes(x):
+def int32_to_bytes(x: np.int32) -> tuple:
     return (x >> 24 & 0xFF, x >> 16 & 0xFF, x >> 8 & 0xFF, x & 0xFF)
 
 
 @njit
-def int64_to_bytes(x):
-    return (
-        x >> 56 & 0xFF,
-        x >> 48 & 0xFF,
-        x >> 40 & 0xFF,
-        x >> 32 & 0xFF,
-        x >> 24 & 0xFF,
-        x >> 16 & 0xFF,
-        x >> 8 & 0xFF,
-        x & 0xFF,
-    )
-
-
-@njit
-def fnv1a32(data: np.int32, seed: np.int32):
+def fnv1a32(num: np.int32, seed: np.int32) -> np.uint64:
     """
-    Returns the 32 bit FNV-1a hash value for the given data.
+    Returns the 32 bit FNV-1a hash value for the given number.
     """
-    # assert isinstance(data, bytes)
 
     hval = 0x811C9DC5 ^ seed
-    for byte in int32_to_bytes(data):
+    for byte in int32_to_bytes(num):
         hval = hval ^ byte
         hval = (hval * 0x01000193) % 2**32
     return np.uint64(hval)
 
 
 @njit
-def fnv1a64(data: np.int32, seed: np.int32):
-    """
-    Returns the 64 bit FNV-1a hash value for the given data.
-    """
-    # assert isinstance(data, bytes)
-
-    hval = 0xCBF29CE484222325 ^ seed
-    for byte in int64_to_bytes(data):
-        hval = hval ^ byte
-        hval = (hval * 0x100000001B3) % 2**64
-    return hval
-
-
-@njit
-def minhash_jit(
-    tokens: npt.NDArray[np.int32],
-    hash_seed: np.int32,  # ,
-    # hash_fn: Callable[[bytes, int], int] = fnv1a,
-) -> np.uint64:
+def minhash_jit(tokens: npt.NDArray[np.int32], hash_seed: np.int32) -> np.uint64:
     empty: npt.NDArray[np.uint64] = np.empty((tokens.shape[0],), dtype=np.uint64)
     for i in range(tokens.shape[0]):
         empty[i] = fnv1a32(tokens[i], hash_seed)

--- a/minlizhash/jit.py
+++ b/minlizhash/jit.py
@@ -79,13 +79,13 @@ def minhash_jit(
 
 @njit
 def minhash_jit_all(
-    tokens: npt.NDArray[np.int32],
-    seeds: npt.NDArray[np.int32],
+    tokens: TokenArray,
+    seeds: PermutationSeeds,
 ) -> npt.NDArray[np.uint64]:
-    signature = np.zeros((seeds.shape[0],), dtype=np.uint64)
-    for i in range(signature.shape[0]):
-        signature[i] = minhash_jit(tokens, seeds[i])
-    return signature
+    arr = np.empty((seeds.shape[0],), dtype=np.uint64)
+    for i in range(seeds.shape[0]):
+        arr[i] = minhash_jit(tokens, seeds[i])
+    return arr
 
 
 class DocumentSignerJIT(DocumentSigner):
@@ -94,7 +94,5 @@ class DocumentSignerJIT(DocumentSigner):
     def __init__(self, hash_function: Callable[[TokenArray, int], int] = minhash_jit):
         self.hash_function = hash_function
 
-    def __call__(
-        self, tokens: TokenArray, seeds: PermutationSeeds
-    ) -> npt.NDArray[np.uint64]:
-        return minhash_jit_all(tokens, seeds)
+    def __call__(self, tokens, seeds) -> npt.NDArray[np.uint64]:
+        return minhash_jit_all(tokens.astype(np.uint64), seeds[:, 0])

--- a/minlizhash/min_hash.py
+++ b/minlizhash/min_hash.py
@@ -56,14 +56,15 @@ def filter_documentlist(
     progress_bar: bool = True,
     jit: bool = True,
     check_candidates_exactly: bool = False,
-    filter_below: float = 0.0,
+    filter_below: float = 0.8,
     leave_one_for_each_duplicate: bool = False,
     existing_index: Union[None, LSH, str] = None,
     index_save_dir: str | None = None,
     save_matches_dir: str | None = None,
     hash_function: Callable[[bytes, int], int] = xxh32_intdigest,
 ) -> List[Document]:
-    """Takes a list of documents and returns a new list of documents with signatures. If JIT is chosen, hash funciton choice will be ignored.
+    """Takes a list of documents and returns a new list of documents with signatures.
+    If JIT is chosen, hash funciton choice will only be used for LSH. Minhash uses a custom implementation w/ JIT.
     Args:
         documentlist: List of documents to be signed
         seed: Seed used to generate the seeds for the permutations.
@@ -136,7 +137,7 @@ def filter_jsonl(
     progress_bar: bool = True,
     jit: bool = True,
     check_candidates_exactly: bool = False,
-    filter_below: float = 0.0,
+    filter_below: float = 0.8,
     leave_one_for_each_duplicate: bool = False,
     existing_index: Union[None, LSH, str] = None,
     index_save_dir: str | None = None,
@@ -145,6 +146,8 @@ def filter_jsonl(
 ) -> None:
     """Takes a jsonl file and returns a new jsonl file with signatures
     May update later to batch load or similar. If you need more customization, all the APIs are internally available.
+    If JIT is chosen, hash funciton choice will only be used for LSH. Minhash uses a custom implementation w/ JIT.
+
     Args:
         input_file: Path to input jsonl file
         output_file: Path to output jsonl file

--- a/poetry.lock
+++ b/poetry.lock
@@ -234,22 +234,20 @@ files = [
 
 [[package]]
 name = "comm"
-version = "0.1.4"
+version = "0.2.0"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "comm-0.1.4-py3-none-any.whl", hash = "sha256:6d52794cba11b36ed9860999cd10fd02d6b2eac177068fdd585e1e2f8a96e67a"},
-    {file = "comm-0.1.4.tar.gz", hash = "sha256:354e40a59c9dd6db50c5cc6b4acc887d82e9603787f83b68c01a80a923984d15"},
+    {file = "comm-0.2.0-py3-none-any.whl", hash = "sha256:2da8d9ebb8dd7bfc247adaff99f24dce705638a8042b85cb995066793e391001"},
+    {file = "comm-0.2.0.tar.gz", hash = "sha256:a517ea2ca28931c7007a7a99c562a0fa5883cfb48963140cf642c41c948498be"},
 ]
 
 [package.dependencies]
 traitlets = ">=4"
 
 [package.extras]
-lint = ["black (>=22.6.0)", "mdformat (>0.7)", "mdformat-gfm (>=0.3.5)", "ruff (>=0.0.156)"]
 test = ["pytest"]
-typing = ["mypy (>=0.990)"]
 
 [[package]]
 name = "debugpy"
@@ -418,13 +416,13 @@ attrs = ">=19.2.0"
 
 [[package]]
 name = "jupyter-client"
-version = "8.5.0"
+version = "8.6.0"
 description = "Jupyter protocol implementation and client libraries"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.5.0-py3-none-any.whl", hash = "sha256:c3877aac7257ec68d79b5c622ce986bd2a992ca42f6ddc9b4dd1da50e89f7028"},
-    {file = "jupyter_client-8.5.0.tar.gz", hash = "sha256:e8754066510ce456358df363f97eae64b50860f30dc1fe8c6771440db3be9a63"},
+    {file = "jupyter_client-8.6.0-py3-none-any.whl", hash = "sha256:909c474dbe62582ae62b758bca86d6518c85234bdee2d908c778db6d72f39d99"},
+    {file = "jupyter_client-8.6.0.tar.gz", hash = "sha256:0642244bb83b4764ae60d07e010e15f0e2d275ec4e918a8f7b80fbbef3ca60c7"},
 ]
 
 [package.dependencies]
@@ -457,6 +455,39 @@ traitlets = ">=5.3"
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
 test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "llvmlite"
+version = "0.41.1"
+description = "lightweight wrapper around basic LLVM functionality"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "llvmlite-0.41.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1e1029d47ee66d3a0c4d6088641882f75b93db82bd0e6178f7bd744ebce42b9"},
+    {file = "llvmlite-0.41.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:150d0bc275a8ac664a705135e639178883293cf08c1a38de3bbaa2f693a0a867"},
+    {file = "llvmlite-0.41.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1eee5cf17ec2b4198b509272cf300ee6577229d237c98cc6e63861b08463ddc6"},
+    {file = "llvmlite-0.41.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dd0338da625346538f1173a17cabf21d1e315cf387ca21b294ff209d176e244"},
+    {file = "llvmlite-0.41.1-cp310-cp310-win32.whl", hash = "sha256:fa1469901a2e100c17eb8fe2678e34bd4255a3576d1a543421356e9c14d6e2ae"},
+    {file = "llvmlite-0.41.1-cp310-cp310-win_amd64.whl", hash = "sha256:2b76acee82ea0e9304be6be9d4b3840208d050ea0dcad75b1635fa06e949a0ae"},
+    {file = "llvmlite-0.41.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:210e458723436b2469d61b54b453474e09e12a94453c97ea3fbb0742ba5a83d8"},
+    {file = "llvmlite-0.41.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:855f280e781d49e0640aef4c4af586831ade8f1a6c4df483fb901cbe1a48d127"},
+    {file = "llvmlite-0.41.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b67340c62c93a11fae482910dc29163a50dff3dfa88bc874872d28ee604a83be"},
+    {file = "llvmlite-0.41.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2181bb63ef3c607e6403813421b46982c3ac6bfc1f11fa16a13eaafb46f578e6"},
+    {file = "llvmlite-0.41.1-cp311-cp311-win_amd64.whl", hash = "sha256:9564c19b31a0434f01d2025b06b44c7ed422f51e719ab5d24ff03b7560066c9a"},
+    {file = "llvmlite-0.41.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5940bc901fb0325970415dbede82c0b7f3e35c2d5fd1d5e0047134c2c46b3281"},
+    {file = "llvmlite-0.41.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8b0a9a47c28f67a269bb62f6256e63cef28d3c5f13cbae4fab587c3ad506778b"},
+    {file = "llvmlite-0.41.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8afdfa6da33f0b4226af8e64cfc2b28986e005528fbf944d0a24a72acfc9432"},
+    {file = "llvmlite-0.41.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8454c1133ef701e8c050a59edd85d238ee18bb9a0eb95faf2fca8b909ee3c89a"},
+    {file = "llvmlite-0.41.1-cp38-cp38-win32.whl", hash = "sha256:2d92c51e6e9394d503033ffe3292f5bef1566ab73029ec853861f60ad5c925d0"},
+    {file = "llvmlite-0.41.1-cp38-cp38-win_amd64.whl", hash = "sha256:df75594e5a4702b032684d5481db3af990b69c249ccb1d32687b8501f0689432"},
+    {file = "llvmlite-0.41.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04725975e5b2af416d685ea0769f4ecc33f97be541e301054c9f741003085802"},
+    {file = "llvmlite-0.41.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bf14aa0eb22b58c231243dccf7e7f42f7beec48970f2549b3a6acc737d1a4ba4"},
+    {file = "llvmlite-0.41.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92c32356f669e036eb01016e883b22add883c60739bc1ebee3a1cc0249a50828"},
+    {file = "llvmlite-0.41.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24091a6b31242bcdd56ae2dbea40007f462260bc9bdf947953acc39dffd54f8f"},
+    {file = "llvmlite-0.41.1-cp39-cp39-win32.whl", hash = "sha256:880cb57ca49e862e1cd077104375b9d1dfdc0622596dfa22105f470d7bacb309"},
+    {file = "llvmlite-0.41.1-cp39-cp39-win_amd64.whl", hash = "sha256:92f093986ab92e71c9ffe334c002f96defc7986efda18397d0f08534f3ebdc4d"},
+    {file = "llvmlite-0.41.1.tar.gz", hash = "sha256:f19f767a018e6ec89608e1f6b13348fa2fcde657151137cb64e56d48598a92db"},
+]
 
 [[package]]
 name = "matplotlib-inline"
@@ -538,6 +569,40 @@ files = [
     {file = "nest_asyncio-1.5.8-py3-none-any.whl", hash = "sha256:accda7a339a70599cb08f9dd09a67e0c2ef8d8d6f4c07f96ab203f2ae254e48d"},
     {file = "nest_asyncio-1.5.8.tar.gz", hash = "sha256:25aa2ca0d2a5b5531956b9e273b45cf664cae2b145101d73b86b199978d48fdb"},
 ]
+
+[[package]]
+name = "numba"
+version = "0.58.1"
+description = "compiling Python code using LLVM"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "numba-0.58.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:07f2fa7e7144aa6f275f27260e73ce0d808d3c62b30cff8906ad1dec12d87bbe"},
+    {file = "numba-0.58.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7bf1ddd4f7b9c2306de0384bf3854cac3edd7b4d8dffae2ec1b925e4c436233f"},
+    {file = "numba-0.58.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc2d904d0319d7a5857bd65062340bed627f5bfe9ae4a495aef342f072880d50"},
+    {file = "numba-0.58.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e79b6cc0d2bf064a955934a2e02bf676bc7995ab2db929dbbc62e4c16551be6"},
+    {file = "numba-0.58.1-cp310-cp310-win_amd64.whl", hash = "sha256:81fe5b51532478149b5081311b0fd4206959174e660c372b94ed5364cfb37c82"},
+    {file = "numba-0.58.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bcecd3fb9df36554b342140a4d77d938a549be635d64caf8bd9ef6c47a47f8aa"},
+    {file = "numba-0.58.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1eaa744f518bbd60e1f7ccddfb8002b3d06bd865b94a5d7eac25028efe0e0ff"},
+    {file = "numba-0.58.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bf68df9c307fb0aa81cacd33faccd6e419496fdc621e83f1efce35cdc5e79cac"},
+    {file = "numba-0.58.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:55a01e1881120e86d54efdff1be08381886fe9f04fc3006af309c602a72bc44d"},
+    {file = "numba-0.58.1-cp311-cp311-win_amd64.whl", hash = "sha256:811305d5dc40ae43c3ace5b192c670c358a89a4d2ae4f86d1665003798ea7a1a"},
+    {file = "numba-0.58.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ea5bfcf7d641d351c6a80e8e1826eb4a145d619870016eeaf20bbd71ef5caa22"},
+    {file = "numba-0.58.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e63d6aacaae1ba4ef3695f1c2122b30fa3d8ba039c8f517784668075856d79e2"},
+    {file = "numba-0.58.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fe7a9d8e3bd996fbe5eac0683227ccef26cba98dae6e5cee2c1894d4b9f16c1"},
+    {file = "numba-0.58.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:898af055b03f09d33a587e9425500e5be84fc90cd2f80b3fb71c6a4a17a7e354"},
+    {file = "numba-0.58.1-cp38-cp38-win_amd64.whl", hash = "sha256:d3e2fe81fe9a59fcd99cc572002101119059d64d31eb6324995ee8b0f144a306"},
+    {file = "numba-0.58.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c765aef472a9406a97ea9782116335ad4f9ef5c9f93fc05fd44aab0db486954"},
+    {file = "numba-0.58.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e9356e943617f5e35a74bf56ff6e7cc83e6b1865d5e13cee535d79bf2cae954"},
+    {file = "numba-0.58.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:240e7a1ae80eb6b14061dc91263b99dc8d6af9ea45d310751b780888097c1aaa"},
+    {file = "numba-0.58.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:45698b995914003f890ad839cfc909eeb9c74921849c712a05405d1a79c50f68"},
+    {file = "numba-0.58.1-cp39-cp39-win_amd64.whl", hash = "sha256:bd3dda77955be03ff366eebbfdb39919ce7c2620d86c906203bed92124989032"},
+    {file = "numba-0.58.1.tar.gz", hash = "sha256:487ded0633efccd9ca3a46364b40006dbdaca0f95e99b8b83e778d1195ebcbaa"},
+]
+
+[package.dependencies]
+llvmlite = "==0.41.*"
+numpy = ">=1.22,<1.27"
 
 [[package]]
 name = "numpy"
@@ -1133,13 +1198,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.6.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "types-tqdm"
-version = "4.66.0.3"
+version = "4.66.0.4"
 description = "Typing stubs for tqdm"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "types-tqdm-4.66.0.3.tar.gz", hash = "sha256:596a3396e7c15d3597c8af68bb3cf3ca0853dad68cea22e21b98dd8203741aff"},
-    {file = "types_tqdm-4.66.0.3-py3-none-any.whl", hash = "sha256:e47cff2e49411e9f8b7190576253de952bfe59c92261f78e8525f3199c8a01e0"},
+    {file = "types-tqdm-4.66.0.4.tar.gz", hash = "sha256:a2f0ebd4cfd48f4914395819a176d7947387e1b98f9228fca38f8cac1b59891c"},
+    {file = "types_tqdm-4.66.0.4-py3-none-any.whl", hash = "sha256:8eda4c5123dd66985a4cb44268705cfa18beb32d66772271ae185e92b8b10c40"},
 ]
 
 [[package]]
@@ -1300,5 +1365,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.12,<3.13"
-content-hash = "99b0ca6b93cec657e9ed032a2a22ae0d36ade79c20cb44a79b930498a232955d"
+python-versions = ">=3.11,<3.12"
+content-hash = "16f2ce55607b34c8c202398bbaff266cf0652060bcb8d662ba4a98eeff62cea3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "minlizhash"
-version = "0.1.0"
+version = "0.2.0"
 description = "A simple MinHash LSH Implimentation from scratch"
 authors = ["Liz Goodwin <work@lizgood.win>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,14 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.13"
+python = ">=3.11,<3.12"
 numpy = "^1.26.1"
 xxhash = "^3.4.1"
 tdqm = "^0.0.1"
 tiktoken = "^0.5.1"
 jsonlines = "^4.0.0"
 types-tqdm = "^4.66.0.3"
+numba = "^0.58.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Used numba to add support for a JIT compiled minhash implimentation. See minlizhash.jit for more details. Approximately a ~70x speedup using the normal Hasher.sign_documents() interface. About twice that if going directly from array to array. 

Uses a custom implimentation of FNV-1a to calculate hashes instead of the default xxhash. Simply set jit = True and it should work (or pass in jit.DocumentSignerJIT instead).

Also made the progress bar optional.